### PR TITLE
fix libuast installation on macOS

### DIFF
--- a/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
+++ b/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
@@ -12,7 +12,7 @@ object Libuast {
   // Extract the native module from the jar
   private def loadBinaryLib(name: String) = {
     val tempDir = System.getProperty("java.io.tmpdir")
-    val ext = if (System.getProperty("os.name").toLowerCase == "mac") ".dylib" else ".so"
+    val ext = if (System.getProperty("os.name").toLowerCase == "mac os x") ".dylib" else ".so"
     val fullLibName = name + ext
     val outPath = Paths.get(tempDir, fullLibName).toString
 


### PR DESCRIPTION
Result of of `os.name` is `Mac OS X`, not `Mac` and thus in macOS it tries to load `libuast.so`

```
scala> System.getProperty("os.name").toLowerCase
res3: String = mac os x
```