### PR TITLE
Fix multithread sync problems

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "bblfsh-client"
 organization := "org.bblfsh"
-version := "1.2.0"
+version := "1.2.1"
 
 scalaVersion := "2.11.11"
 val libuastVersion = "v1.2.0"

--- a/src/main/scala/org/bblfsh/client/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/BblfshClient.scala
@@ -31,9 +31,7 @@ class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
   }
 
   def filter(node: Node, query: String): List[Node] = {
-    Libuast.synchronized {
-      libuast.filter(node, query)
-    }
+    libuast.filter(node, query)
   }
 }
 

--- a/src/main/scala/org/bblfsh/client/libuast/nodeiface.c
+++ b/src/main/scala/org/bblfsh/client/libuast/nodeiface.c
@@ -7,8 +7,6 @@ extern "C" {
 #include <stdint.h>
 #include <jni.h>
 
-extern JNIEnv *env;
-
 static const char *InternalType(const void *node)
 {
   return ReadStr((const jobject*)node, "internalType");
@@ -31,6 +29,10 @@ static int RolesSize(const void *node)
 
 static void *ChildAt(const void *data, int index)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jobject *node = (jobject *)data;
   jobject childSeq = ObjectField(CLS_NODE, node, "children", SIGN_SEQ);
   if ((*env)->ExceptionOccurred(env))
@@ -45,6 +47,10 @@ static void *ChildAt(const void *data, int index)
 
 static int PropertiesSize(const void *data)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return 0;
+
   jobject *node = (jobject *)data;
   jobject propsMap = ObjectField(CLS_NODE, node, "properties", SIGN_MAP);
   if ((*env)->ExceptionOccurred(env) || !propsMap)
@@ -55,6 +61,10 @@ static int PropertiesSize(const void *data)
 
 static const char *PropertyAt(const void *data, int index)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jobject *node = (jobject *)data;
   jobject propsMap = ObjectField(CLS_NODE, node, "properties", SIGN_MAP);
   if ((*env)->ExceptionOccurred(env) || !propsMap)
@@ -80,6 +90,10 @@ static const char *PropertyAt(const void *data, int index)
 
 static uint16_t RoleAt(const void *data, int index)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return 0;
+
   jobject *node = (jobject *)data;
   jobject roleSeq = ObjectField(CLS_NODE, node, "roles", SIGN_SEQ);
   if ((*env)->ExceptionOccurred(env) || !roleSeq)

--- a/src/main/scala/org/bblfsh/client/libuast/org_bblfsh_client_libuast_Libuast.h
+++ b/src/main/scala/org/bblfsh/client/libuast/org_bblfsh_client_libuast_Libuast.h
@@ -17,6 +17,8 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_libuast_Libuast_filter
   (JNIEnv *, jobject, jobject, jstring);
 
 
+jint JNI_OnLoad(JavaVM *vm, void *reserved);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/main/scala/org/bblfsh/client/libuast/utils.c
+++ b/src/main/scala/org/bblfsh/client/libuast/utils.c
@@ -33,10 +33,34 @@ const char *CLS_TUPLE2 = "scala/Tuple2";
 const char *CLS_LIST = "scala/collection/immutable/List";
 const char *CLS_MUTLIST = "scala/collection/mutable/MutableList";
 
-extern JNIEnv *env;
+extern JavaVM *jvm;
+
+JNIEnv *getJNIEnv()
+{
+  JNIEnv *pEnv = NULL;
+
+  switch ((*jvm)->GetEnv(jvm, (void **)&pEnv, JNI_VERSION_1_8))
+  {
+    case JNI_OK:
+      // Thread is ready to use, nothing to do
+      break;
+
+    case JNI_EDETACHED:
+      // Thread is detached, need to attach
+      (*jvm)->AttachCurrentThread(jvm, (void **)&pEnv, NULL);
+      break;
+  }
+
+  return pEnv;
+}
 
 const char *AsNativeStr(jstring jstr)
 {
+
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   const char *tmp = (*env)->GetStringUTFChars(env, jstr, 0);
   if ((*env)->ExceptionOccurred(env) || !tmp)
     return NULL;
@@ -61,6 +85,10 @@ jobject *ToObjectPtr(jobject *object)
 jint IntMethod(const char *method, const char *signature, const char *className,
          const jobject *object)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return 0;
+
   jclass cls = (*env)->FindClass(env, className);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return 0;
@@ -79,6 +107,10 @@ jint IntMethod(const char *method, const char *signature, const char *className,
 jobject ObjectMethod(const char *method, const char *signature, const char *typeName,
            const jobject object, ...)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jclass cls = (*env)->FindClass(env, typeName);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return NULL;
@@ -98,6 +130,10 @@ jobject ObjectMethod(const char *method, const char *signature, const char *type
 jobject ObjectField(const char *typeName, const jobject *obj, const char *field,
           const char *signature)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jclass cls = (*env)->FindClass(env, typeName);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return NULL;
@@ -119,6 +155,10 @@ jobject ObjectField(const char *typeName, const jobject *obj, const char *field,
 
 jobject NewJavaObject(const char *className, const char *initSign, ...)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jclass cls = (*env)->FindClass(env, className);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return NULL;
@@ -139,6 +179,10 @@ jobject NewJavaObject(const char *className, const char *initSign, ...)
 
 const char *ReadStr(const jobject *node, const char *property)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return NULL;
+
   jclass cls = (*env)->FindClass(env, CLS_NODE);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return NULL;
@@ -152,6 +196,10 @@ const char *ReadStr(const jobject *node, const char *property)
 
 int ReadLen(const jobject *node, const char *property)
 {
+  JNIEnv *env = getJNIEnv();
+  if (!env)
+    return 0;
+
   jclass cls = (*env)->FindClass(env, CLS_NODE);
   if ((*env)->ExceptionOccurred(env) || !cls)
     return 0;

--- a/src/main/scala/org/bblfsh/client/libuast/utils.h
+++ b/src/main/scala/org/bblfsh/client/libuast/utils.h
@@ -26,6 +26,8 @@ extern const char *CLS_TUPLE2;
 extern const char *CLS_LIST;
 extern const char *CLS_MUTLIST;
 
+JNIEnv *getJNIEnv();
+
 jobject *ToObjectPtr(jobject*);
 
 const char *AsNativeStr(jstring);

--- a/src/test/scala/org/bblf/client/BblfshClientTest.scala
+++ b/src/test/scala/org/bblf/client/BblfshClientTest.scala
@@ -48,4 +48,18 @@ class BblfshClientTest extends FunSuite with BeforeAndAfter {
     var filtered = client.filter(resp.uast.get, "//QualifiedName[@roleExpression]")
     assert(filtered.length == 3)
   }
+
+  test("XPath query with threads") {
+    val th = new Thread(new Runnable {
+      def run() {
+        var filtered = client.filter(resp.uast.get, "//QualifiedName[@roleExpression]")
+        assert(filtered.length == 3)
+      }
+    })
+    th.start
+
+    th.synchronized {
+      th.wait
+    }
+  }
 }


### PR DESCRIPTION
- Don't share the `JNIEnv` pointer among threads.
- Synchronize from the C module using `MonitorEnter/Exit`.
- Always return an immutable list, even when empty.
- New test that failed with the fixed problem.
- Bump version.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>