### PR TITLE
Synchronized on the Libuast Object didn't work.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "bblfsh-client"
 organization := "org.bblfsh"
-version := "1.3.1"
+version := "1.3.2"
 
 scalaVersion := "2.11.11"
 val libuastVersion = "v1.3.0"

--- a/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
+++ b/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
@@ -7,35 +7,38 @@ import java.nio.file.Paths
 import org.apache.commons.io.{IOUtils, FileUtils}
 
 object Libuast {
-  var loaded = false
+  final var loaded = false
 
   // Extract the native module from the jar
-  private def loadBinaryLib(name: String) = synchronized {
-    val tempDir = System.getProperty("java.io.tmpdir")
+  private final def loadBinaryLib(name: String) = {
     val ext = if (System.getProperty("os.name").toLowerCase == "mac os x") ".dylib" else ".so"
     val fullLibName = name + ext
-    val outPath = Paths.get(tempDir, fullLibName).toString
-
     val in = getClass.getResourceAsStream(Paths.get("/lib", fullLibName).toString)
-    val fout = new File(outPath)
+
+    val prefix = "libscalauast_"
+    val fout = File.createTempFile(prefix, ext)
     val out = FileUtils.openOutputStream(fout)
 
     try {
       IOUtils.copy(in, out)
-      System.load(outPath)
-      loaded = true
     } finally {
       in.close()
       out.close()
     }
-  }
 
+    System.load(fout.getAbsolutePath)
+    loaded = true
+  }
 }
 
 class Libuast {
-  private val libName = "libscalauast"
-  if (!Libuast.loaded) {
-    Libuast.loadBinaryLib(libName)
+  initialize()
+
+  // Note: moving this to the Object doesn't synchronize correctly
+  private def initialize() = Libuast.synchronized {
+    if (!Libuast.loaded) {
+      Libuast.loadBinaryLib("libscalauast")
+    }
   }
 
   @native def filter(node: Node, query: String): List[Node]


### PR DESCRIPTION
For some reason that I still doesn't understand, a method in the `Libuast` Object with a `synchronized` or a `Libuast.synchronized` doesn't work (in the sense that it doesn't avoid simultaneous accesses by several threads; checked with `println`'s with the PID while running inside Spark). 

But `Libuast.synchronize` does if called from the `Libuast` Class constructor instead of the Object.

(╯°□°）╯︵ ┻━┻

While I was at it, I modified it to generate the library file using a tmp path so even if two or more processes run at the same time they shouldn't collide.

Fixes #30

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>