### PR TITLE
Make Node.filter() work.

### DIFF
--- a/src/main/scala/org/bblfsh/client/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/BblfshClient.scala
@@ -9,7 +9,7 @@ import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
 import io.grpc.ManagedChannelBuilder
 
 
-class BblfshClient(host: String, port: Int, maxMsgSize: Int) { 
+class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
   private val channel = ManagedChannelBuilder
     .forAddress(host, port)
     .usePlaintext(true)

--- a/src/main/scala/org/bblfsh/client/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/BblfshClient.scala
@@ -29,7 +29,9 @@ class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
     parsed
   }
 
-  // proxy to the static method for backward compatibility
+  /**
+   * Proxy for Bblfsh.filter / Node.filter, provided for backward compatibility.
+   */
   def filter(node: Node, query: String): List[Node] = {
     BblfshClient.filter(node, query)
   }

--- a/src/main/scala/org/bblfsh/client/cli/ScalaClientCLI.scala
+++ b/src/main/scala/org/bblfsh/client/cli/ScalaClientCLI.scala
@@ -22,7 +22,7 @@ object ScalaClientCLI extends App {
 
   if (resp.errors.isEmpty) {
     if (query != null && query != "") {
-      println(client.filter(resp.uast.get, query))
+      println(BblfshClient.filter(resp.uast.get, query))
     } else {
       println(resp.uast.get)
     }


### PR DESCRIPTION
Fixed #37.

- Added implicit class in the Object for calling Node.filter.

- Moved filter to the Object (static Scala style) since it doesn't need
  the this pointer and it's needed there for the implicit object to work
  without a reference to the client instance.

- Reworked test to use Node.filter and added a shortcut to resp.uast.get.

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>