### PR TITLE
Fix/track strings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import sys.process._
 
 name := "bblfsh-client"
 organization := "org.bblfsh"
-version := "1.5.0"
+version := "1.5.1"
 
 scalaVersion := "2.11.11"
 val libuastVersion = "v1.3.0"

--- a/src/main/scala/org/bblfsh/client/libuast/jni_utils.c
+++ b/src/main/scala/org/bblfsh/client/libuast/jni_utils.c
@@ -75,6 +75,7 @@ const char *AsNativeStr(jstring jstr) {
 
   // str must be copied to deref the java string before return
   const char *cstr = strdup(tmp);
+  trackObject((void *)cstr);
 
   (*env)->ReleaseStringUTFChars(env, jstr, tmp);
   if ((*env)->ExceptionOccurred(env))
@@ -86,7 +87,7 @@ const char *AsNativeStr(jstring jstr) {
 jobject *ToObjectPtr(jobject *object) {
   jobject *copy = malloc(sizeof(jobject));
   memcpy(copy, object, sizeof(jobject));
-  trackObject(copy);
+  trackObject((void *)copy);
   return copy;
 }
 

--- a/src/main/scala/org/bblfsh/client/libuast/objtrack.c
+++ b/src/main/scala/org/bblfsh/client/libuast/objtrack.c
@@ -9,7 +9,7 @@ extern "C" {
 #include <stdlib.h>
 
 typedef struct {
-  jobject **vector;
+  void **vector;
   size_t used;
   size_t size;
 } AllocVector;
@@ -20,20 +20,20 @@ static void initAllocVector() {
   const int initialSize = 128;
 
   _allocVector = (AllocVector *)malloc(sizeof(AllocVector));
-  _allocVector->vector = (jobject **)malloc(initialSize * sizeof(jobject*));
+  _allocVector->vector = (void **)malloc(initialSize * sizeof(void*));
   _allocVector->used = 0;
   _allocVector->size = initialSize;
 }
 
-void trackObject(jobject *obj) {
+void trackObject(void *obj) {
   if (_allocVector == NULL || _allocVector->vector == NULL) {
     initAllocVector();
   }
 
   if (_allocVector->used == _allocVector->size) {
     _allocVector->size *= 2;
-    _allocVector->vector = (jobject **)realloc(_allocVector->vector,
-                           _allocVector->size * sizeof(jobject*));
+    _allocVector->vector = (void **)realloc(_allocVector->vector,
+                           _allocVector->size * sizeof(void*));
   }
   _allocVector->vector[_allocVector->used++] = obj;
 }

--- a/src/main/scala/org/bblfsh/client/libuast/objtrack.h
+++ b/src/main/scala/org/bblfsh/client/libuast/objtrack.h
@@ -7,7 +7,7 @@ extern "C" {
 
 #include <jni.h>
 
-void trackObject(jobject *);
+void trackObject(void *);
 
 void freeObjects();
 


### PR DESCRIPTION
Track also the allocated c-strings in `AsNativeStr` (called by `ReadStr` and other parts of the code). Uses the same vector, just changing it's type to `void*`.