### PR TITLE
Position iterator and bugfix.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ import sys.process._
 
 name := "bblfsh-client"
 organization := "org.bblfsh"
-version := "1.7.0"
+version := "1.8.0"
 
 scalaVersion := "2.11.11"
-val libuastVersion = "v1.8.2"
-val sdkVersion = "v1.13.0"
+val libuastVersion = "v1.9.0"
+val sdkVersion = "v1.14.0"
 val sdkMajor = "v1"
 val protoDir = "src/main/proto"
 

--- a/src/main/scala/org/bblfsh/client/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/BblfshClient.scala
@@ -69,9 +69,10 @@ class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
 object BblfshClient {
   val DEFAULT_MAX_MSG_SIZE = 100 * 1024 * 1024
 
-  val PreOrder = 0
-  val PostOrder = 1
-  val LevelOrder = 2
+  val PreOrder      = 0
+  val PostOrder     = 1
+  val LevelOrder    = 2
+  val PositionOrder = 3
 
   private val libuast = new Libuast
 

--- a/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
+++ b/src/main/scala/org/bblfsh/client/libuast/Libuast.scala
@@ -21,7 +21,11 @@ object Libuast {
     }
 
     override def next(): Node = {
-      nextIterator(iterPtr)
+      val res = nextIterator(iterPtr)
+      if (res == null) {
+        close() 
+      }
+      res
     }
 
     def close() = {

--- a/src/main/scala/org/bblfsh/client/libuast/org_bblfsh_client_libuast_Libuast.cc
+++ b/src/main/scala/org/bblfsh/client/libuast/org_bblfsh_client_libuast_Libuast.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <cstdlib>
+#include <cstdio>
 #include <unordered_map>
 #include <vector>
 
@@ -58,6 +59,7 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_libuast_Libuast_00024UastIterat
   (JNIEnv *env, jobject self, jobject iteratorPtr) {
 
     UastIterator *iter = (UastIterator*) env->GetDirectBufferAddress(iteratorPtr);
+
     if (env->ExceptionCheck() == JNI_TRUE) {
       return NULL;
     }
@@ -68,6 +70,10 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_libuast_Libuast_00024UastIterat
     memTracker.SetCurrentIterator(iter, false);
 
     jobject *retNode = (jobject *)UastIteratorNext(iter);
+    if (retNode == NULL) {
+      // end of the iteration reached
+      return NULL;
+    }
     return *retNode;
 }
 

--- a/src/test/scala/org/bblf/client/BblfshClientIteratorTest.scala
+++ b/src/test/scala/org/bblf/client/BblfshClientIteratorTest.scala
@@ -3,6 +3,7 @@ package org.bblfsh.client
 import org.bblfsh.client.BblfshClient._
 
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
+import gopkg.in.bblfsh.sdk.v1.uast.generated.Position
 import org.scalatest.FunSuite
 import org.scalatest.BeforeAndAfter
 
@@ -13,11 +14,22 @@ class BblfshClientIterator extends FunSuite with BeforeAndAfter {
   var rootNode: Node = _
 
   before {
-    val child1 = new Node(internalType = "child1")
-    val subchild21 = new Node(internalType = "subchild21")
-    val subchild22 = new Node(internalType = "subchild22")
-    val child2 = new Node(internalType = "child2", children = List(subchild21, subchild22))
-    rootNode = new Node(internalType = "parent", children = List(child1, child2))
+    val child1 = new Node(internalType = "child1", 
+                          startPosition = Some(Position(offset = 1)))
+
+    val subchild21 = new Node(internalType = "subchild21", 
+                              startPosition = Some(Position(offset = 6)))
+
+    val subchild22 = new Node(internalType = "subchild22", 
+                              startPosition = Some(Position(offset = 5)))
+
+    val child2 = new Node(internalType = "child2", 
+                          startPosition = Some(Position(offset = 2)),
+                          children = List(subchild21, subchild22))
+
+    rootNode = new Node(internalType = "parent", 
+                        startPosition = Some(Position(offset = 0)),
+                        children = List(child1, child2))
   }
 
   test("Use as a range") {
@@ -45,8 +57,6 @@ class BblfshClientIterator extends FunSuite with BeforeAndAfter {
     assert(it.hasNext())
     n = it.next()
     assert(n.internalType == "subchild22")
-
-    it.close()
   }
 
   test("PostOrder iterator") {
@@ -71,8 +81,6 @@ class BblfshClientIterator extends FunSuite with BeforeAndAfter {
     assert(it.hasNext())
     n = it.next()
     assert(n.internalType == "parent")
-
-    it.close()
   }
 
   test("LevelOrder iterator") {
@@ -97,7 +105,32 @@ class BblfshClientIterator extends FunSuite with BeforeAndAfter {
     assert(it.hasNext())
     n = it.next()
     assert(n.internalType == "subchild22")
+  }
 
-    it.close()
+  test("PositionOrder iterator") {
+    var it = BblfshClient.iterator(rootNode, BblfshClient.PositionOrder)
+
+    assert(it.hasNext())
+    var n = it.next()
+    assert(n.internalType == "parent")
+
+    assert(it.hasNext())
+    n = it.next()
+    assert(n.internalType == "child1")
+
+    assert(it.hasNext())
+    n = it.next()
+    assert(n.internalType == "child2")
+
+    assert(it.hasNext())
+    n = it.next()
+    assert(n.internalType == "subchild22")
+
+    assert(it.hasNext())
+    n = it.next()
+    assert(n.internalType == "subchild21")
+
+    n = it.next()
+    assert(!it.hasNext())
   }
 }


### PR DESCRIPTION
- Position iterator.
- Bumped versions.
- Fix a potential NULL dereference.
- Makes `close()` be automatically called at the end of the iteration
  (calling `close()` again will not fail but will do nothing).

Signed-off-by: Juanjo Alvarez <juanjo@sourced.tech>