### PR TITLE
Update scalapb version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,12 +14,12 @@ mainClass in Compile := Some("org.bblfsh.client.cli.ScalaClientCLI")
 
 target in assembly := file("build")
 
-libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % com.trueaccord.scalapb.compiler.Version.scalapbVersion % "protobuf"
+libraryDependencies += "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
 libraryDependencies += "commons-io" % "commons-io" % "2.5"
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "io.grpc" % "grpc-netty" % com.trueaccord.scalapb.compiler.Version.grpcJavaVersion,
-  "com.trueaccord.scalapb" %% "scalapb-runtime-grpc" % com.trueaccord.scalapb.compiler.Version.scalapbVersion,
+  "io.grpc" % "grpc-netty" % scalapb.compiler.Version.grpcJavaVersion,
+  "com.thesamet.scalapb" %% "scalapb-runtime-grpc" % scalapb.compiler.Version.scalapbVersion,
   "org.rogach" %% "scallop" % "3.0.3"
 )
 

--- a/project/scalapb.sbt
+++ b/project/scalapb.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.11")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.16")
 
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.1"


### PR DESCRIPTION
Since scalapb 0.6.0 there are a lot of improvements: https://github.com/scalapb/ScalaPB/compare/v0.6.0...master

Besides changes in the library itself protoc, java-grcp were updated. Now it includes proto files from protobuf-3.3.1.