### PR TITLE
Revert "Use a precompiled package for osxcross for CI."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,23 @@ before_install:
 
 env:
   global:
-   - OSXCROSS_PACKAGE="osxcross_3034f7149716d815bc473d0a7b35d17e4cf175aa.tar.gz"
-   - OSXCROSS_URL="https://github.com/bblfsh/client-scala/releases/download/v1.5.2/${OSXCROSS_PACKAGE}"
+   - OSXCROSS_PATH="$HOME/osxcross"
+   - OSXCROSS_REV=3034f7149716d815bc473d0a7b35d17e4cf175aa
+   - SDK_VERSION=10.11
+   - DARWIN_VERSION=15
+   - OSX_VERSION_MIN=10.6
+   - OSXCROSS_SDK_URL="https://s3.dockerproject.org/darwin/v2/MacOSX10.11.sdk.tar.xz"
 
 install:
- - cd ${HOME}
- - curl -sSL ${OSXCROSS_URL} | tar -C ${HOME} -xzf - 
+ - mkdir -p /tmp/osxcross
+ - cd /tmp/osxcross
+ - curl -sSL "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" | tar -C /tmp/osxcross --strip=1 -xzf -
+ - curl -s -S -L -o tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz ${OSXCROSS_SDK_URL}
+ - UNATTENDED=yes ./build.sh >/dev/null
+ - mv target "${OSXCROSS_PATH}"
+ - curl -S -L "https://github.com/karalabe/xgo/blob/647f256c447ee20f9bf13ebc42e612d55994a383/docker/base/patch.tar.xz?raw=true" | xz -dc - | tar -xf -
+ - mv v1 "${OSXCROSS_PATH}/SDK/MacOSX${SDK_VERSION}.sdk/usr/include/c++/v1"
+ - rm -rf /tmp/osxcross "${OSXCROSS_PATH}/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
 
 script:
  - cd $TRAVIS_BUILD_DIR

--- a/build.sbt
+++ b/build.sbt
@@ -164,7 +164,7 @@ def compileMacOS(sourceFiles: String): Unit = {
     return
   }
 
-  val cmd = osxHome + "/bin/o64-clang -shared -Wall -fPIC -O2 -lxml2 " +
+  val cmd = osxHome + "/bin/o64-clang++-libc++ -shared -Wall -fPIC -O2 -lxml2 -std=c++11 " +
       "-I" + osxHome + "/SDK/MacOSX10.11.sdk/usr/include/libxml2/ " +
       "-I" + osxHome + "/SDK/src/libuast-native/roles.c " +
       "-I" + osxHome + "/SDK/MacOSX10.11.sdk/usr/include/ " +

--- a/src/main/scala/org/bblfsh/client/libuast/memtracker.cc
+++ b/src/main/scala/org/bblfsh/client/libuast/memtracker.cc
@@ -1,4 +1,5 @@
 #include "memtracker.h"
+#include <cstdlib>
 #include <cstdio>
 
 UastIterator* MemTracker::CurrentIterator() { return currentIter_; }

--- a/src/test/scala/org/bblf/client/BblfshClientParseTest.scala
+++ b/src/test/scala/org/bblf/client/BblfshClientParseTest.scala
@@ -112,7 +112,7 @@ class BblfshClientParseTest extends FunSuite with BeforeAndAfter {
 
   test("Xpath filter StartLine") {
     val filtered = rootNode.filter("//*[@startLine='1']");
-    assert(filtered.length == 17)
+    assert(filtered.length == 28)
     val filteredNeg = rootNode.filter("//*[@startLine='100']");
     assert(filteredNeg.length == 0)
   }
@@ -133,7 +133,7 @@ class BblfshClientParseTest extends FunSuite with BeforeAndAfter {
 
   test("Xpath filter EndLine") {
     val filtered = rootNode.filter("//*[@endLine='1']");
-    assert(filtered.length == 16)
+    assert(filtered.length == 26)
     val filteredNeg = rootNode.filter("//*[@endLine='100']");
     assert(filteredNeg.length == 0)
   }


### PR DESCRIPTION
Tarball doesn't have `libscalauast.dylib`, also nobody updates precompiled version. Looks like speedup of CI doesn't worth it.

This reverts commit 96efacdef21d25b1d885c7d16977f7725f54f159.

Now I use sdk from xgo because it has a patch for c++.
Arguments for clang has been changed to be able to compile c++ code.
`memtracker.cc` includes new header otherwise it doesn't build on macos.

Tests with start&end positions were updated because the bug in driver was fixed.