### PR TITLE
Add support to query supported languages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ version := "1.8.2"
 
 scalaVersion := "2.11.11"
 val libuastVersion = "v1.9.1"
-val sdkVersion = "v1.14.0"
+val sdkVersion = "v1.16.0"
 val sdkMajor = "v1"
 val protoDir = "src/main/proto"
 
@@ -148,6 +148,7 @@ def compileLinux(sourceFiles: String) = {
     "-I/usr/include " +
     "-I" + javaHome + "/include/ " +
     "-I" + javaHome + "/include/linux " +
+    "-I" + javaHome + "/include/darwin " +
     "-Isrc/libuast-native/  " +
     "-o lib/libscalauast.so " + 
     sourceFiles +

--- a/src/main/scala/org/bblfsh/client/BblfshClient.scala
+++ b/src/main/scala/org/bblfsh/client/BblfshClient.scala
@@ -5,6 +5,7 @@ import org.bblfsh.client.libuast.Libuast
 import gopkg.in.bblfsh.sdk.v1.protocol.generated.{Encoding, ProtocolServiceGrpc,
                                                   ParseRequest, ParseResponse,
                                                   NativeParseRequest, NativeParseResponse,
+                                                  SupportedLanguagesRequest, SupportedLanguagesResponse,
                                                   VersionRequest, VersionResponse}
 import gopkg.in.bblfsh.sdk.v1.uast.generated.Node
 
@@ -39,6 +40,11 @@ class BblfshClient(host: String, port: Int, maxMsgSize: Int) {
                                  language = BblfshClient.normalizeLanguage(lang),
                                  encoding = encoding)
     stub.nativeParse(req)
+  }
+
+  def supportedLanguages(): SupportedLanguagesResponse = {
+    val req = SupportedLanguagesRequest()
+    stub.supportedLanguages(req)
   }
 
   def version(): VersionResponse = {

--- a/src/test/scala/org/bblf/client/BblfshClientSupportedLanguagesTest.scala
+++ b/src/test/scala/org/bblf/client/BblfshClientSupportedLanguagesTest.scala
@@ -12,7 +12,11 @@ class BblfshClientSupportedLanguagesTest extends FunSuite with BeforeAndAfter {
     resp = client.supportedLanguages()
   }
 
-  test("Check languages") {
+  test("Check languages are not empty") {
     assert(!resp.languages.isEmpty)
+  }
+
+  test("Check languages contain Java") {
+    assert(resp.languages.map(d => d.name).contains("Java"))
   }
 }

--- a/src/test/scala/org/bblf/client/BblfshClientSupportedLanguagesTest.scala
+++ b/src/test/scala/org/bblf/client/BblfshClientSupportedLanguagesTest.scala
@@ -1,0 +1,18 @@
+package org.bblf.client
+
+import gopkg.in.bblfsh.sdk.v1.protocol.generated.SupportedLanguagesResponse
+import org.bblfsh.client.BblfshClient
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+class BblfshClientSupportedLanguagesTest extends FunSuite with BeforeAndAfter {
+  val client = BblfshClient("0.0.0.0", 9432)
+  var resp: SupportedLanguagesResponse = _
+
+  before {
+    resp = client.supportedLanguages()
+  }
+
+  test("Check languages") {
+    assert(!resp.languages.isEmpty)
+  }
+}


### PR DESCRIPTION
Fix: #68

1. Update sdk version
2. Add `supportedLanguages` method and test
3. Add `"-I" + javaHome + "/include/darwin "` to libuast build.sbt. It allows to build `client-scala` on mac.