### PR TITLE
encode() and a stub for the load()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,10 @@ jobs:
         - sudo apt-get install -y binutils
         - ./sbt assembly
         - ./sbt "testOnly *Close* *ClientVersion* *SupportedLanguages*"
+        - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Parsed UAST for .java file\""
         - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Decoded UAST after parsing\""
         - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Decoded UAST RootNode\""
+
       after_failure: *failure_logs_anchor
 
     - name: 'Cross-compile, release & publish to Sonatype'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,7 @@ jobs:
       script:
         - sudo apt-get install -y binutils
         - ./sbt assembly
-        - ./sbt "testOnly *Close* *ClientVersion* *SupportedLanguages*"
-        - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Parsed UAST for .java file\""
-        - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Decoded UAST after parsing\""
-        - ./sbt "testOnly org.bblfsh.client.v2.BblfshClientParseTest -- -z \"Decoded UAST RootNode\""
+        - ./sbt "testOnly *Close* *ClientVersion* *SupportedLanguages* *BblfshClientParseTest"
 
       after_failure: *failure_logs_anchor
 

--- a/src/main/native/org_bblfsh_client_v2_Context.h
+++ b/src/main/native/org_bblfsh_client_v2_Context.h
@@ -18,10 +18,10 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_root
 /*
  * Class:     org_bblfsh_client_v2_Context
  * Method:    encode
- * Signature: (Lorg/bblfsh/client/v2/Node;I)Ljava/nio/ByteBuffer;
+ * Signature: (Lorg/bblfsh/client/v2/Node;)Ljava/nio/ByteBuffer;
  */
 JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_encode
-  (JNIEnv *, jobject, jobject, jint);
+  (JNIEnv *, jobject, jobject);
 
 /*
  * Class:     org_bblfsh_client_v2_Context

--- a/src/main/native/org_bblfsh_client_v2_Node.h
+++ b/src/main/native/org_bblfsh_client_v2_Node.h
@@ -10,7 +10,7 @@ extern "C" {
 /*
  * Class:     org_bblfsh_client_v2_Node
  * Method:    load
- * Signature: ()Lscala/collection/immutable/Map;
+ * Signature: ()Lorg/bblfsh/client/v2/JNode;
  */
 JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Node_load
   (JNIEnv *, jobject);

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -15,6 +15,8 @@ jobject asJvmBuffer(uast::Buffer buf) {
   return env->NewDirectByteBuffer(buf.ptr, buf.size);
 }
 
+const char *nativeContext = "nativeContext";
+
 jfieldID getHandleField(JNIEnv *env, jobject obj, const char *name) {
   jclass cls = env->GetObjectClass(obj);
   if (env->ExceptionOccurred() || !cls) {
@@ -145,7 +147,7 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_libuast_Libuast_filter(
 // v2.Context()
 JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_root(JNIEnv *env,
                                                                  jobject self) {
-  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
+  ContextExt *p = getHandle<ContextExt>(env, self, nativeContext);
   return p->RootNode();
 }
 
@@ -153,14 +155,14 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_encode(
     JNIEnv *env, jobject self, jobject node) {
   UastFormat fmt = UAST_BINARY;  // TODO(bzz): make it argument & enum
 
-  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
+  ContextExt *p = getHandle<ContextExt>(env, self, nativeContext);
   return p->Encode(node, fmt);
 }
 
 JNIEXPORT void JNICALL Java_org_bblfsh_client_v2_Context_dispose(JNIEnv *env,
                                                                  jobject self) {
-  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
-  setHandle<ContextExt>(env, self, 0, "nativeContext");
+  ContextExt *p = getHandle<ContextExt>(env, self, nativeContext);
+  setHandle<ContextExt>(env, self, 0, nativeContext);
   delete p;
 }
 

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -155,7 +155,6 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_encode(
 
   ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
   return p->Encode(node, fmt);
-  return nullptr;
 }
 
 JNIEXPORT void JNICALL Java_org_bblfsh_client_v2_Context_dispose(JNIEnv *env,

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -137,16 +137,9 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_libuast_Libuast_decode(
   return jCtxExt;
 }
 
-JNIEXPORT void JNICALL Java_org_bblfsh_client_v2_Context_dispose(JNIEnv *env,
-                                                                 jobject self) {
-  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
-  setHandle<ContextExt>(env, self, 0, "nativeContext");
-  delete p;
-}
-
 JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_libuast_Libuast_filter(
     JNIEnv *, jobject, jobject, jstring) {
-  return NULL;  // TODO(bzz): implement
+  return nullptr;  // TODO(bzz): implement
 }
 
 // v2.Context()
@@ -154,6 +147,19 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_root(JNIEnv *env,
                                                                  jobject self) {
   ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
   return p->RootNode();
+}
+
+JNIEXPORT void JNICALL Java_org_bblfsh_client_v2_Context_dispose(JNIEnv *env,
+                                                                 jobject self) {
+  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
+  setHandle<ContextExt>(env, self, 0, "nativeContext");
+  delete p;
+}
+
+// v2.Node()
+JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Node_load(JNIEnv *,
+                                                              jobject) {
+  return nullptr;  // TODO(bzz): implement
 }
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -93,7 +93,7 @@ class ContextExt {
     return toJ(root);
   }
 
-  // Encode serializes existing-on-guest-side UAST.
+  // Encode serializes external UAST.
   // Borrows the reference.
   jobject Encode(jobject node, UastFormat format) {
     NodeHandle h = toHandle(node);
@@ -147,6 +147,15 @@ JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_root(JNIEnv *env,
                                                                  jobject self) {
   ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
   return p->RootNode();
+}
+
+JNIEXPORT jobject JNICALL Java_org_bblfsh_client_v2_Context_encode(
+    JNIEnv *env, jobject self, jobject node) {
+  UastFormat fmt = UAST_BINARY;  // TODO(bzz): make it argument & enum
+
+  ContextExt *p = getHandle<ContextExt>(env, self, "nativeContext");
+  return p->Encode(node, fmt);
+  return nullptr;
 }
 
 JNIEXPORT void JNICALL Java_org_bblfsh_client_v2_Context_dispose(JNIEnv *env,

--- a/src/main/scala/org/bblfsh/client/v2/Context.scala
+++ b/src/main/scala/org/bblfsh/client/v2/Context.scala
@@ -4,7 +4,7 @@ import java.nio.ByteBuffer
 	
 case class Context(nativeContext: Long) {
     @native def root(): Node
-    @native def encode(n: Node, format: Int): ByteBuffer
+    @native def encode(n: Node): ByteBuffer
     @native def dispose()
 
     @native def filter()

--- a/src/main/scala/org/bblfsh/client/v2/JNode.scala
+++ b/src/main/scala/org/bblfsh/client/v2/JNode.scala
@@ -1,0 +1,11 @@
+package org.bblfsh.client.v2
+
+sealed abstract class JNode
+case class JString(s: String) extends JNode
+case class JDouble(num: Double) extends JNode
+case class JLong(num: Long) extends JNode
+case class JInt(num: BigInt) extends JNode
+case class JBool(value: Boolean) extends JNode
+case class JObject(obj: List[JField]) extends JNode
+case class JArray(arr: List[JNode]) extends JNode
+

--- a/src/main/scala/org/bblfsh/client/v2/JNode.scala
+++ b/src/main/scala/org/bblfsh/client/v2/JNode.scala
@@ -1,5 +1,9 @@
 package org.bblfsh.client.v2
 
+/** UAST nodes representation on the JVM side.
+ *
+ *  Mirrors https://godoc.org/github.com/bblfsh/sdk/uast/nodes
+ */
 sealed abstract class JNode
 case class JString(s: String) extends JNode
 case class JDouble(num: Double) extends JNode

--- a/src/main/scala/org/bblfsh/client/v2/Node.scala
+++ b/src/main/scala/org/bblfsh/client/v2/Node.scala
@@ -1,6 +1,5 @@
 package org.bblfsh.client.v2
 
 case class Node(ctx: Long, handle: Long) {
-  // TODO(bzz) make sure single string value or an array can also be loaded
-  @native def load(): Map[String, _]
+  @native def load(): JNode
 }

--- a/src/main/scala/org/bblfsh/client/v2/package.scala
+++ b/src/main/scala/org/bblfsh/client/v2/package.scala
@@ -1,5 +1,11 @@
 package org.bblfsh.client
 
+/** Bblfsh client for protocol v2.
+ *  See https://github.com/bblfsh/sdk/blob/v3.1.0/protocol/driver.proto
+ *
+ *  The main class to use is [[org.bblfsh.client.v2.BblfshClient]]
+ */
 package object v2 {
+    /** Key, Value representation of [[org.bblfsh.client.v2.JObject]] */
     type JField = (String, JNode)
 }

--- a/src/main/scala/org/bblfsh/client/v2/package.scala
+++ b/src/main/scala/org/bblfsh/client/v2/package.scala
@@ -1,0 +1,5 @@
+package org.bblfsh.client
+
+package object v2 {
+    type JField = (String, JNode)
+}

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientCloseTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientCloseTest.scala
@@ -1,9 +1,7 @@
 package org.bblfsh.client.v2
 
-import gopkg.in.bblfsh.sdk.v2.protocol.driver.VersionResponse
 import org.scalatest.{BeforeAndAfter, FunSuite}
 
-import scala.io.Source
 
 class BblfshClientClose extends FunSuite with BeforeAndAfter {
   val client = BblfshClient("0.0.0.0", 9432)

--- a/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
+++ b/src/test/scala/org/bblfsh/client/v2/BblfshClientParseTest.scala
@@ -55,11 +55,11 @@ class BblfshClientParseTest extends FlatSpec
   }
 
   "Encoding back the RootNode of decoded UAST" should "produce same bytes" in {
-    val uast = resp.uast.decode()
-    val rootNode: Node = uast.root()
+    val uastCtx: Context = resp.uast.decode()
+    val rootNode: Node = uastCtx.root()
     println(s"Root node: $rootNode")
 
-    val encodedBytes: ByteBuffer = uast.encode(rootNode, 0)
+    val encodedBytes: ByteBuffer = uastCtx.encode(rootNode)
 
     encodedBytes.capacity should be (resp.uast.asReadOnlyByteBuffer.capacity)
     encodedBytes shouldEqual resp.uast.asReadOnlyByteBuffer


### PR DESCRIPTION
Another part of #83

 - `Context.encode()` implementation  + tests
 - a stub for `Node.load()`

Actual load() implementation will be done in subsequent PRs.