### PR TITLE
Rename repo to scala-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ libraryDependencies += "org.bblfsh" % "bblfsh-client" % version
 
 ### Dependencies
 
-You need to install libxml2, the Java SDK and its header files. The command for
+You need to install the Java SDK and its header files. The command for
 Debian and derived distributions would be:
 
 ```
-sudo apt install libxml2-dev openjdk-8 openjdk-8-jdk-headless
+sudo apt install openjdk-8 openjdk-8-jdk-headless
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Babelfish Scala client [![Build Status](https://travis-ci.org/bblfsh/client-scala.svg?branch=master)](https://travis-ci.org/bblfsh/client-scala)
+## Babelfish Scala client [![Build Status](https://travis-ci.org/bblfsh/scala-client.svg?branch=master)](https://travis-ci.org/bblfsh/scala-client)
 
 This a Scala/JNI implementation of the [Babelfish](https://doc.bblf.sh/) client.
 It uses [ScalaPB](https://scalapb.github.io/grpc.html) for Protobuf/gRPC code
@@ -12,8 +12,8 @@ Current `scala-client` v1.x only supports bblfsh protocol and UASTv1.
 
 #### Manual
 ```
-git clone https://github.com/bblfsh/client-scala.git
-cd client-scala
+git clone https://github.com/bblfsh/scala-client.git
+cd scala-client
 ./sbt assembly
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,9 @@ PB.protoSources in Compile := Seq(file(protoDir))
 sonatypeProfileName := "org.bblfsh"
 
 // pom settings for sonatype
-homepage := Some(url("https://github.com/bblfsh/client-scala"))
-scmInfo := Some(ScmInfo(url("https://github.com/bblfsh/client-scala"),
-                            "git@github.com:bblfsh/client-scala.git"))
+homepage := Some(url("https://github.com/bblfsh/scala-client"))
+scmInfo := Some(ScmInfo(url("https://github.com/bblfsh/scala-client"),
+                            "git@github.com:bblfsh/scala-client.git"))
 developers += Developer("juanjux",
                         "Juanjo Álvarez",
                         "juanjo@sourced.tech",

--- a/src/main/native/jni_utils.cc
+++ b/src/main/native/jni_utils.cc
@@ -2,7 +2,7 @@
 #include <string>
 
 // TODO(bzz): double-check and document. Suggestion and more context at
-// https://github.com/bblfsh/client-scala/pull/84#discussion_r288347756
+// https://github.com/bblfsh/scala-client/pull/84#discussion_r288347756
 extern JavaVM *jvm;
 
 JNIEnv *getJNIEnv() {

--- a/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
+++ b/src/main/native/org_bblfsh_client_v2_libuast_Libuast.cc
@@ -11,7 +11,7 @@
 #include "libuast.hpp"
 
 // TODO(bzz): double-check and document. Suggestion and more context at
-// https://github.com/bblfsh/client-scala/pull/84#discussion_r288347756
+// https://github.com/bblfsh/scala-client/pull/84#discussion_r288347756
 JavaVM *jvm;
 
 namespace {


### PR DESCRIPTION
Fixes #86, together with actual GH repo rename that can be done after this is merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bblfsh/client-scala/96)
<!-- Reviewable:end -->
